### PR TITLE
fix the frontend deployment with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             - API_HOST=http://localhost:8000
             - API_USER=user@gmail.com
             - API_PASSWORD=password
-        volumes: ["./frontend:/app"]
+        volumes: ["./frontend/src:/app/src"]
         ports:
             - "1234:1234"
             - "1235:1235"


### PR DESCRIPTION
Addresses #148 issue.

The problem was that the during docker-compose run, the `/app` folder in the container was completely overwritten by the content of the host `./frontend` folder that's why all installed packages were gone. I've made it so that only `src` subfolder is mounted and tested that the hotreload is working in dev