### PR TITLE
Use let instead of const to define variable that is reassigned later

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -86,7 +86,7 @@ export default function Home() {
   };
 
   useEffect(() => {
-    const url = `${API_HOST}/leads?page=${page}&perpage=${perpage}`;
+    let url = `${API_HOST}/leads?page=${page}&perpage=${perpage}`;
     const pagesUrl = `${API_HOST}/leads/n_pages?perpage=${perpage}`;
     const token = localStorage.getItem('partnerFinderToken');
     const headers = {


### PR DESCRIPTION
Using the search bar was crashing the home page because we used `const` to define a variable, and then reassigned it later.

Changed `const` to `let`.

Closes #157 