### PR TITLE
fix: frontend dockerfile builds on M1 chips

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,11 @@ ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json ./
 COPY yarn.lock ./
 
+RUN apk --no-cache --virtual build-dependencies add \
+        python \
+        make \
+        g++
+
 RUN yarn install
 
 COPY . ./


### PR DESCRIPTION
### Description

There is an issue with M1 chips and not being able to find Python in the Docker build. The fix is to install Python, make, and g++ so that Python can be found during the yarn install task.

A similar issue can be found here: https://github.com/docker/getting-started/issues/124

Fixes #194 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
<img width="202" alt="Screen Shot 2021-10-16 at 8 17 48 PM" src="https://user-images.githubusercontent.com/3081483/137607898-63ec28f0-6859-4e0c-9ea7-e8125118906f.png">

Before these changes:
<img width="1012" alt="Screen Shot 2021-10-16 at 8 19 26 PM" src="https://user-images.githubusercontent.com/3081483/137607942-25dd3bee-25e2-45ee-aa4c-4da83a668587.png">


- Run `docker-compose up --build -d` and verify that the build is successful.
<img width="1035" alt="Screen Shot 2021-10-16 at 8 18 44 PM" src="https://user-images.githubusercontent.com/3081483/137607923-8e3229e3-97ae-494f-9067-0012e71d028c.png">

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
